### PR TITLE
handleIndex() handles URL's without extentions or with .html extentions

### DIFF
--- a/src/MainModule.js
+++ b/src/MainModule.js
@@ -265,7 +265,7 @@ module.exports.main = function (options) {
 		//we only care about javascript files
 		var pathname = parsedURL.pathname;
 
-		if (pathname === '/' || path.extname(pathname) === '.html') {
+		if (path.extname(pathname) === '' || path.extname(pathname) === '.html') {
 			logger.debug("trying to serve index: " + pathname);
 			module.exports.handleIndex(request, response, next);
 		} else {


### PR DESCRIPTION
All URL's that aren't file requests get pointed at the index.html file in mappings
