### PR TITLE
Rewrote mappings sorter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "browser-pack": "^5.0.0",
     "browser-resolve": "^1.9.0",
     "chokidar": "^1.0.3",
+    "connect-static-file": "^1.0.3",
     "insert-module-globals": "^6.4.2",
     "load-script": "^1.0.0",
     "lodash": "^3.8.0",

--- a/src/MainModule.js
+++ b/src/MainModule.js
@@ -284,10 +284,12 @@ module.exports.main = function (options) {
                 response.setHeader('Content-Type', 'application/javascript');
                 logger.debug("trying to serve javascript: " + pathname);
                 module.exports.handleJavascript(request, response, parsedURL);
-            } else {
-                logger.debug("trying to serve static file: " + pathname);
-                module.exports.handleStatic(response, resolvedURL, next);
-            }
+			} else if ((resolvedURL.extname || path.extname(resolvedURL)) === '.scss') {
+				next()
+			} else {
+				logger.debug("trying to serve static file: " + pathname);
+				module.exports.handleStatic(response, resolvedURL, next);
+			}
         } else if (path.extname(pathname) === '') {
             logger.debug("trying to serve the default index");
             request.url = '/';

--- a/src/MainModule.js
+++ b/src/MainModule.js
@@ -265,7 +265,7 @@ module.exports.main = function (options) {
 		//we only care about javascript files
 		var pathname = parsedURL.pathname;
 
-		if (pathname === '/' || path.extname(pathname) === '.html') {
+		if (path.extname(pathname) === '' || path.extname(pathname) === '.html') {
 			logger.debug("trying to serve index: " + pathname);
 			module.exports.handleIndex(request, response, next);
 		} else {

--- a/src/MainModule.js
+++ b/src/MainModule.js
@@ -161,7 +161,7 @@ module.exports = {
 
     handleStatic : function (response, file, next) {
 
-        if (fs.exists(file)) {
+        if (fs.lstatSync(file)) {
             var content = fs.readFileSync(file).toString();
         } else {
             return next()

--- a/tests/index.html
+++ b/tests/index.html
@@ -5,15 +5,15 @@
 		<title>STORM serve</title>
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<script src="a.js"></script>
-		<script src="test1.js"></script>
-		<script src="test2.js"></script>
-		<script src="test3.js"></script>
-		<link rel="stylesheet" type="text/css" href="main.scss">
-		<link rel="stylesheet" type="text/css" href="main2.scss">
+		<script src="/a.js"></script>
+		<script src="/test1.js"></script>
+		<script src="/test2.js"></script>
+		<script src="/test3.js"></script>
+		<link rel="stylesheet" type="text/css" href="/main.scss">
+		<link rel="stylesheet" type="text/css" href="/main2.scss">
 	</head>
 	<body>
 		<div id="react"><%= react %></div>
-		<script src="static.js"></script>
+		<script src="/static.js"></script>
 	</body>
 </html>

--- a/tests/js/c.js
+++ b/tests/js/c.js
@@ -3,7 +3,7 @@ var React = require("react");
 module.exports = {
 	fetchD: function(){
 		window.onload = function(){
-			window.loadModule("d.js");
+			window.loadModule("/../d.js");
 		};
 	},
 	confirmDLoaded: function(){

--- a/tests/server.js
+++ b/tests/server.js
@@ -17,6 +17,7 @@ app.use(SessionModule.main({
 		"/+(a|d).js" : __dirname + "/../tests/js",
 		"/*.scss" : __dirname + "/../tests/sass",
 		"/json": __dirname + "/../tests/static/static.json",
+		"/css": __dirname + "/../tests/static/static.css",
 		"/test1.js"	  : function(url){
 			return {src: "console.log('test1 worked');", extname:'.js'};
 		}

--- a/tests/server.js
+++ b/tests/server.js
@@ -13,9 +13,10 @@ app.use(SessionModule.main({
 	 * @required
 	 */
 	mappings : {
-		"/index.html" : __dirname + "/../tests/index.html",
+		"/" : __dirname + "/../tests/index.html",
 		"/+(a|d).js" : __dirname + "/../tests/js",
 		"/*.scss" : __dirname + "/../tests/sass",
+        "/json": __dirname + "/../tests/stati/static.json",
 		"/test1.js"	  : function(url){
 			return {src: "console.log('test1 worked');", extname:'.js'};
 		}
@@ -28,7 +29,7 @@ app.use(SessionModule.main({
 		//required for react to work
 		process.env.NODE_ENV = 'development';
 		var data = {
-			react : React.renderToString(React.DOM.img({src:"logo.png"}))
+			react : React.renderToString(React.DOM.img({src:"/logo.png"}))
 		};
 		return (_.template(content))(data);
 	},

--- a/tests/server.js
+++ b/tests/server.js
@@ -16,7 +16,7 @@ app.use(SessionModule.main({
 		"/" : __dirname + "/../tests/index.html",
 		"/+(a|d).js" : __dirname + "/../tests/js",
 		"/*.scss" : __dirname + "/../tests/sass",
-        "/json": __dirname + "/../tests/stati/static.json",
+		"/json": __dirname + "/../tests/static/static.json",
 		"/test1.js"	  : function(url){
 			return {src: "console.log('test1 worked');", extname:'.js'};
 		}

--- a/tests/static/static.css
+++ b/tests/static/static.css
@@ -1,0 +1,3 @@
+body {
+    background: inherit;
+}

--- a/tests/static/static.json
+++ b/tests/static/static.json
@@ -1,0 +1,3 @@
+{
+  "served": "json file"
+}


### PR DESCRIPTION
Serve returns files based on the resolvedURL. Some things I changed:
- Base index referenced by `'/'`.
- Can serve indexes by globbing.
- Can map routes to static, or non (js | scss | html) files.

Working with tests.
